### PR TITLE
Make logger initialization idempotent to prevent duplicate logger errors

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,6 @@
 use std::sync::Arc;
+use env_logger::Env;
+use log::debug;
 use mongodb::{Client, Database};
 use once_cell::sync::OnceCell;
 
@@ -74,7 +76,10 @@ impl Spark {
     pub fn use_db(){
         
     }
+
     fn init_logger() {
-        env_logger::init();
+        if let Err(err) = env_logger::try_init_from_env(Env::new().default_filter_or("info")) {
+            debug!("The logger has already been initialized. {err}")
+        }
     }
 }


### PR DESCRIPTION
**Description:**
This PR modifies the init_logger function to ensure that it handles cases where the logger has already been initialized.
Previously, the function unconditionally called env_logger::init(), which caused errors when another library or part of the application had already initialized the logger.

The updated implementation uses env_logger::try_init_from_env with a default log level of info and logs a debug message if initialization fails due to the logger already being initialized.

**Changes:**

- Replaced env_logger::init() with env_logger::try_init_from_env.
- Added a debug log to notify when the logger is already initialized.

**Benefits:**

- Prevents runtime panics or errors when the logger is initialized multiple times.
- Improves compatibility with other libraries that also use env_logger.

**Checklist:**

-  Functionality tested locally
-  Maintains backward compatibility
-  Properly logs debug information for troubleshooting